### PR TITLE
Seperate Application into swift package

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "name": "Launch",
       "type": "lldb",
       "request": "launch",
-      "program": "~/Library/Developer/Xcode/DerivedData/Demo-avuzscipzqxczrbltxhlvbnxujdo/Build/Products/Debug-${command:ios-debug.targetSdk}/Demo.app",
+      "program": "~/Library/Developer/Xcode/DerivedData/Demo/Build/Products/Debug-${command:ios-debug.targetSdk}/Demo.app",
       "iosBundleId": "dev.mt.Demo",
       "iosTarget": "select",
       "preLaunchTask": "${defaultBuildTask}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
 
   "[swift]": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,10 @@
         "-target",
         "-Xswiftc",
         "arm64-apple-ios13.0-simulator"
-      ]
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/Main"
+      }
     },
     {
       "label": "xcodegen",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,6 +35,11 @@
       "command": "xcodegen"
     },
     {
+      "label": "clean",
+      "type": "shell",
+      "command": "rm -R -f ~/Library/Developer/Xcode/DerivedData/Demo/Result.xcresult"
+    },
+    {
       "label": "xcodebuild",
       "type": "process",
       "command": "xcodebuild",
@@ -46,11 +51,11 @@
         "-sdk",
         "${command:ios-debug.targetSdk}",
         "-derivedDataPath",
-        "~/Library/Developer/Xcode/DerivedData/Demo-avuzscipzqxczrbltxhlvbnxujdo", // <- use `BUILD_DIR`?
-        // "-clonedSourcePackagesDirPath",
-        // "./Main/.build",
-        // "-resultBundlePath",
-        // "./ResultBundlePath",
+        "~/Library/Developer/Xcode/DerivedData/Demo", // <- use `BUILD_DIR`?
+        "-clonedSourcePackagesDirPath",
+        "./Main/.build",
+        "-resultBundlePath",
+        "~/Library/Developer/Xcode/DerivedData/Demo/Result.xcresult",
         "-allowProvisioningUpdates",
         "ARCHS=arm64"
       ],
@@ -58,7 +63,7 @@
         "kind": "build",
         "isDefault": true
       },
-      "dependsOn": ["xcodegen"]
+      "dependsOn": ["xcodegen", "clean"]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,6 +47,10 @@
         "${command:ios-debug.targetSdk}",
         "-derivedDataPath",
         "~/Library/Developer/Xcode/DerivedData/Demo-avuzscipzqxczrbltxhlvbnxujdo", // <- use `BUILD_DIR`?
+        // "-clonedSourcePackagesDirPath",
+        // "./Main/.build",
+        // "-resultBundlePath",
+        // "./ResultBundlePath",
         "-allowProvisioningUpdates",
         "ARCHS=arm64"
       ],

--- a/Application/Application.swift
+++ b/Application/Application.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Main
 
 #if DEBUG
 @_exported import Inject

--- a/Main/Package.swift
+++ b/Main/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
     .library(name: packageName, targets: [packageName])
   ],
   dependencies: [
-    .package(url: "https://github.com/krzysztofzablocki/Inject.git", .branch("main"))
+    .package(url: "https://github.com/krzysztofzablocki/Inject.git", .branch("main")),
+    .package(url: "https://github.com/johnno1962/HotReloading.git", .branch("main"))
   ],
   targets: [
     .target(
@@ -26,6 +27,12 @@ let package = Package(
       dependencies: [
         .byNameItem(
           name: "Inject",
+          condition: .when(platforms: [
+            .iOS
+          ])
+        ),
+        .byNameItem(
+          name: "HotReloading",
           condition: .when(platforms: [
             .iOS
           ])

--- a/Main/Package.swift
+++ b/Main/Package.swift
@@ -3,7 +3,7 @@
 
 import PackageDescription
 
-let packageName = "Demo"
+let packageName = "Main"
 
 // Necessary for `sourcekit-lsp` support in VSCode:`
 
@@ -31,7 +31,7 @@ let package = Package(
           ])
         )
       ],
-      path: packageName
+      path: "Sources"
     )
   ]
 )

--- a/Main/Sources/ContentView.swift
+++ b/Main/Sources/ContentView.swift
@@ -4,10 +4,15 @@ import SwiftUI
 import Inject
 #endif
 
-struct ContentView: View {
-  var body: some View {
+public struct ContentView: View {
+
+  public init() {
+
+  }
+
+  public var body: some View {
     VStack {
-      Text("Hello World")
+      Text("Testing")
         .padding()
         .background(Color.red)
         .border(.blue)

--- a/Main/Sources/ContentView.swift
+++ b/Main/Sources/ContentView.swift
@@ -5,7 +5,6 @@ import Inject
 #endif
 
 public struct ContentView: View {
-
   public init() {
 
   }
@@ -23,10 +22,4 @@ public struct ContentView: View {
   #if DEBUG
   @ObserveInjection var inject
   #endif
-}
-
-struct ContentView_Previews: PreviewProvider {
-  static var previews: some View {
-    ContentView()
-  }
 }

--- a/README.md
+++ b/README.md
@@ -10,23 +10,3 @@ Demonstrating vscode development environment using xcodegen + HotReloading.
 - SwiftUI injection property wrapper with [Inject](https://github.com/krzysztofzablocki/Inject.git)
 
 ![hotreloading-vscode-ios 2022-06-03 20_10_56](https://user-images.githubusercontent.com/274318/171922061-cabbb0aa-b2ba-4ade-a606-41a06c3c2ca3.gif)
-
-## Support HotReloading
-
-One caveat to support HotReloading is to ensure the `derivedDataPath` passed to `xcodebuild` matches that when building with Xcode.
-
-Xcode (by default) uses "Unique" build locations for each project: [Xcode DerivedData Hashes](https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html)
-
-Once the `xcodegen` task has been run the following command can be used to output the `$BUILT_PRODUCTS_DIR` including the unique location (for this demo):
-
-```shell
-$xcodebuild -project ./Demo.xcodeproj -scheme Demo -showBuildSettings | grep -m 1 "BUILT_PRODUCTS_DIR" | grep -oEi "\/.*"
-```
-
-Output:
-
-```
-~/Library/Developer/Xcode/DerivedData/Demo-avuzscipzqxczrbltxhlvbnxujdo/Build/Products/Debug-iphoneos
-```
-
-This in turn means the `.vscode/launch.json` iOS Debug `program` needs to be updated to resolve to the output `*.app` (`$CODESIGNING_FOLDER_PATH`)

--- a/project.yml
+++ b/project.yml
@@ -2,22 +2,17 @@ name: Demo
 options:
   bundleIdPrefix: dev.mt
 packages:
-  HotReloading:
-    url: https://github.com/johnno1962/HotReloading.git
-    branch: main
-  Inject:
-    url: https://github.com/krzysztofzablocki/Inject.git
-    branch: main
+  Main:
+    path: ./Main
 targets:
   Demo:
     type: application
     platform: iOS
     deploymentTarget: "14.0"
-    sources: [Application, Demo]
+    sources: [Application]
     dependencies:
       - sdk: SwiftUI.framework
-      - package: HotReloading
-      - package: Inject
+      - package: Main
     settings:
       base:
         CURRENT_PROJECT_VERSION: 1


### PR DESCRIPTION
Avoids having to add packages into Package.swift as well as xcodegen's project.yml.

Main is now an independent swift package with its dependencies, then xcodeproj will add this package.